### PR TITLE
Dash_bug

### DIFF
--- a/charts/kafka-exporter/templates/deployment.yaml
+++ b/charts/kafka-exporter/templates/deployment.yaml
@@ -49,8 +49,8 @@ spec:
             {{- end }}
             {{- if .Values.kafkaExporter.tls.enabled}}
             - --tls.enabled
-            {{- if .Values.kafkaExporter.tls.insecure-skip-tls-verify}}
-            - --tls.insecure-skip-tls-verify
+            {{- if .Values.kafkaExporter.tls.insecureSkipTlsVerify}}
+            - --tls.insecureSkipTlsVerify
             {{- else }}
             - --tls.ca-file=/etc/tls-certs/{{ .Values.kafkaExporter.tls.caFileName }}
             - --tls.cert-file=/etc/tls-certs/{{ .Values.kafkaExporter.tls.certFileName}}
@@ -88,7 +88,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 9
 
-          {{- if and (.Values.kafkaExporter.tls.enabled) (not .Values.kafkaExporter.tls.insecure-skip-tls-verify) }}
+          {{- if and (.Values.kafkaExporter.tls.enabled) (not .Values.kafkaExporter.tls.insecureSkipTlsVerify) }}
           volumeMounts:
           - name: "tls-certs"
             mountPath: "/etc/tls-certs/"
@@ -108,7 +108,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if and (.Values.kafkaExporter.tls.enabled) (not .Values.kafkaExporter.tls.insecure-skip-tls-verify) }}
+    {{- if and (.Values.kafkaExporter.tls.enabled) (not .Values.kafkaExporter.tls.insecureSkipTlsVerify) }}
       volumes:
       - name: "tls-certs"
         secret:

--- a/charts/kafka-exporter/values.yaml
+++ b/charts/kafka-exporter/values.yaml
@@ -36,7 +36,7 @@ kafkaExporter:
   tls:
     enabled: true
     secretName: "example-kafka-user"
-    insecure-skip-tls-verify: false
+    insecureSkipTlsVerify: false
     caFileName: "ca.crt"
     certFileName: "tls.crt"
     keyFileName: "tls.key"


### PR DESCRIPTION
Dashes in values causes error when parsing:
```
helm template --debug .
install.go:159: [debug] Original chart version: ""
install.go:176: [debug] CHART PATH: /Users/rmcwilliams/git/kafka_exporter/charts/kafka-exporter


Error: parse error at (kafka-exporter/templates/deployment.yaml:52): bad character U+002D '-'
helm.go:84: [debug] parse error at (kafka-exporter/templates/deployment.yaml:52): bad character U+002D '-'
```

Switching to camel casing fixed the issue and I was able to render the YAML without issue. 